### PR TITLE
postモデルのUserIDフィールドをUserモデルと紐付ける

### DIFF
--- a/src/interfaces/resolver/graphql/schema.graphql
+++ b/src/interfaces/resolver/graphql/schema.graphql
@@ -25,6 +25,7 @@ type Post {
   created_at: Time!
   updated_at: Time!
   user_id: ID!
+  user: User!
 }
 
 input CreatePostInput {

--- a/src/interfaces/resolver/resolver.go
+++ b/src/interfaces/resolver/resolver.go
@@ -18,9 +18,15 @@ func (r *Resolver) Mutation() graphql.MutationResolver {
 	return &mutationResolver{r}
 }
 
+func (r *Resolver) Post() graphql.PostResolver {
+	return &postResolver{r}
+}
+
 type queryResolver struct{ *Resolver }
 
 type mutationResolver struct{ *Resolver }
+
+type postResolver struct{ *Resolver }
 
 type contextKey string
 

--- a/src/interfaces/resolver/user_resolver.go
+++ b/src/interfaces/resolver/user_resolver.go
@@ -47,10 +47,19 @@ func (r *mutationResolver) DeleteUser(ctx context.Context) (bool, error) {
 	}
 	return r.UserInteractor.DeleteUser(ctx, &user_grpc.ID{Id: userID})
 }
+
 func (r *mutationResolver) Login(ctx context.Context, in gen.LoginInput) (*gen.UserWithToken, error) {
 	req := &user_grpc.LoginReq{
 		Email:    in.Email,
 		Password: in.Password,
 	}
 	return r.UserInteractor.Login(ctx, req)
+}
+
+func (r *postResolver) User(ctx context.Context, obj *graphql.Post) (*graphql.User, error) {
+	intID, err := strconv.ParseInt(obj.UserID, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	return r.UserInteractor.User(ctx, &user_grpc.ID{Id: intID})
 }


### PR DESCRIPTION
# WHY
graphqlのpostクエリでuserの情報を取れるようにするため
# WHAT
postモデルのUserIDフィールドをUserモデルと紐付け、gqlgenでリゾルバーを生成する